### PR TITLE
adding assignmentExpression entity, assigning init of loopControl to it

### DIFF
--- a/src/FAST-Fortran-Entities/FASTFortranAssignmentExpression.class.st
+++ b/src/FAST-Fortran-Entities/FASTFortranAssignmentExpression.class.st
@@ -1,0 +1,95 @@
+"
+I represent an assignment expression as a part of assignment statement
+"
+Class {
+	#name : #FASTFortranAssignmentExpression,
+	#superclass : #FASTFortranEntity,
+	#traits : 'FASTFortranTExpression',
+	#classTraits : 'FASTFortranTExpression classTrait',
+	#instVars : [
+		'#leftPart => FMOne type: #FASTFortranVariable opposite: #parentAssignmentExpression',
+		'#rightPart => FMOne type: #FASTFortranVariable opposite: #parentAssignmentExpression',
+		'#parentLoopControlExpresison => FMOne type: #FASTFortranLoopControlExpression opposite: #init'
+	],
+	#category : #'FAST-Fortran-Entities-Entities'
+}
+
+{ #category : #meta }
+FASTFortranAssignmentExpression class >> annotation [
+
+	<FMClass: #AssignmentExpression super: #FASTFortranEntity>
+	<package: #'FAST-Fortran-Entities'>
+	<generated>
+	^ self
+]
+
+{ #category : #accessing }
+FASTFortranAssignmentExpression >> leftPart [
+	"Relation named: #leftPart type: #FASTFortranVariable opposite: #parentAssignmentExpression"
+
+	<generated>
+	<FMComment: 'assignee'>
+	^ leftPart
+]
+
+{ #category : #accessing }
+FASTFortranAssignmentExpression >> leftPart: anObject [
+
+	<generated>
+	leftPart := anObject
+]
+
+{ #category : #navigation }
+FASTFortranAssignmentExpression >> leftPartGroup [
+	<generated>
+	<navigation: 'LeftPart'>
+	^ MooseSpecializedGroup with: self leftPart
+]
+
+{ #category : #accessing }
+FASTFortranAssignmentExpression >> parentLoopControlExpresison [
+	"Relation named: #parentLoopControlExpresison type: #FASTFortranLoopControlExpression opposite: #init"
+
+	<generated>
+	<FMComment: 'Parent loop control expresison'>
+	<container>
+	<derived>
+	^ parentLoopControlExpresison
+]
+
+{ #category : #accessing }
+FASTFortranAssignmentExpression >> parentLoopControlExpresison: anObject [
+
+	<generated>
+	parentLoopControlExpresison := anObject
+]
+
+{ #category : #navigation }
+FASTFortranAssignmentExpression >> parentLoopControlExpresisonGroup [
+	<generated>
+	<navigation: 'ParentLoopControlExpresison'>
+	^ MooseSpecializedGroup with: self parentLoopControlExpresison
+]
+
+{ #category : #accessing }
+FASTFortranAssignmentExpression >> rightPart [
+	"Relation named: #rightPart type: #FASTFortranVariable opposite: #parentAssignmentExpression"
+
+	<generated>
+	<FMComment: 'assigned'>
+	^ rightPart
+]
+
+{ #category : #accessing }
+FASTFortranAssignmentExpression >> rightPart: anObject [
+
+	<generated>
+	rightPart := anObject
+]
+
+{ #category : #navigation }
+FASTFortranAssignmentExpression >> rightPartGroup [
+	<generated>
+	<navigation: 'RightPart'>
+	^ MooseSpecializedGroup with: self rightPart
+]

--- a/src/FAST-Fortran-Entities/FASTFortranLoopControlExpression.class.st
+++ b/src/FAST-Fortran-Entities/FASTFortranLoopControlExpression.class.st
@@ -7,8 +7,8 @@ Class {
 	#traits : 'FASTFortranTExpression',
 	#classTraits : 'FASTFortranTExpression classTrait',
 	#instVars : [
-		'#init => FMProperty',
 		'#increment => FMProperty',
+		'#init => FMOne type: #FASTFortranAssignmentExpression opposite: #parentLoopControlExpresison',
 		'#limit => FMProperty',
 		'#parentLoop => FMOne type: #FASTFortranDoStatement opposite: #loopControl'
 	],
@@ -41,17 +41,25 @@ FASTFortranLoopControlExpression >> increment: anObject [
 
 { #category : #accessing }
 FASTFortranLoopControlExpression >> init [
+	"Relation named: #init type: #FASTFortranAssignmentExpression opposite: #parentLoopControlExpresison"
 
-	<FMProperty: #init type: #String>
 	<generated>
-	<FMComment: 'Loop control initial value'>
+	<FMComment: 'initial assignment'>
 	^ init
 ]
 
 { #category : #accessing }
 FASTFortranLoopControlExpression >> init: anObject [
+
 	<generated>
 	init := anObject
+]
+
+{ #category : #navigation }
+FASTFortranLoopControlExpression >> initGroup [
+	<generated>
+	<navigation: 'Init'>
+	^ MooseSpecializedGroup with: self init
 ]
 
 { #category : #accessing }

--- a/src/FAST-Fortran-Entities/FASTFortranTEntityCreator.trait.st
+++ b/src/FAST-Fortran-Entities/FASTFortranTEntityCreator.trait.st
@@ -45,6 +45,13 @@ FASTFortranTEntityCreator >> newArrayVariable [
 ]
 
 { #category : #'entity creation' }
+FASTFortranTEntityCreator >> newAssignmentExpression [
+
+	<generated>
+	^ self add: FASTFortranAssignmentExpression new
+]
+
+{ #category : #'entity creation' }
 FASTFortranTEntityCreator >> newAssignmentStatement [
 
 	<generated>

--- a/src/FAST-Fortran-Entities/FASTFortranVariable.class.st
+++ b/src/FAST-Fortran-Entities/FASTFortranVariable.class.st
@@ -8,6 +8,7 @@ Class {
 	#classTraits : 'FASTFortranTExpression classTrait + FASTFortranTVariableEntity classTrait',
 	#instVars : [
 		'#name => FMProperty',
+		'#parentAssignmentExpression => FMOne type: #FASTFortranAssignmentExpression opposite: #leftPart',
 		'#parentDeclaration => FMOne type: #FASTFortranDeclarationStatement opposite: #declarators'
 	],
 	#category : #'FAST-Fortran-Entities-Entities'
@@ -35,6 +36,31 @@ FASTFortranVariable >> name [
 FASTFortranVariable >> name: anObject [
 	<generated>
 	name := anObject
+]
+
+{ #category : #accessing }
+FASTFortranVariable >> parentAssignmentExpression [
+	"Relation named: #parentAssignmentExpression type: #FASTFortranAssignmentExpression opposite: #leftPart"
+
+	<generated>
+	<FMComment: 'Parent assignment expression'>
+	<container>
+	<derived>
+	^ parentAssignmentExpression
+]
+
+{ #category : #accessing }
+FASTFortranVariable >> parentAssignmentExpression: anObject [
+
+	<generated>
+	parentAssignmentExpression := anObject
+]
+
+{ #category : #navigation }
+FASTFortranVariable >> parentAssignmentExpressionGroup [
+	<generated>
+	<navigation: 'ParentAssignmentExpression'>
+	^ MooseSpecializedGroup with: self parentAssignmentExpression
 ]
 
 { #category : #accessing }

--- a/src/FAST-Fortran-Generator/FASTFortranGenerator.class.st
+++ b/src/FAST-Fortran-Generator/FASTFortranGenerator.class.st
@@ -98,7 +98,8 @@ Class {
 		'tFortranUnaryExpression',
 		'booleanConstant',
 		'characterConstant',
-		'statementBlock'
+		'statementBlock',
+		'assignmentExpression'
 	],
 	#category : #'FAST-Fortran-Generator'
 }
@@ -154,6 +155,11 @@ FASTFortranGenerator >> defineData [
 		                        'I represent a declaration statement for one or many variables'.
 
 	"EXPRESSIONS"
+	
+	assignmentExpression := builder
+		                       newClassNamed: #AssignmentExpression
+		                       comment:
+		                       'I represent an assignment expression as a part of assignment statement'.
 
 	variable := builder
 		            newClassNamed: #Variable
@@ -444,13 +450,13 @@ FASTFortranGenerator >> defineHierarchy [
 
 
 	"DATA"
+	assignmentExpression --|> tExpression.
 	functionCall --|> tExpression.
 	variable --|> tExpression.
 	variable --|> tVariableEntity.
 	variableScalar --|> variable.
 	variableArray --|> variable.
 	loopControlExpression --|> tExpression.
-
 	substring --|> tExpression.
 	
 	binaryExpression --|> tBinaryExpression.
@@ -516,9 +522,6 @@ FASTFortranGenerator >> defineProperties [
 
 	(arrayDimensionDeclarator property: #ub type: #Number) comment:
 		'Upper bound'.
-
-	(loopControlExpression property: #init type: #String) comment:
-		'Loop control initial value'.
 
 	(loopControlExpression property: #increment type: #String) comment:
 		'Loop control increment value'.
@@ -589,6 +592,21 @@ FASTFortranGenerator >> defineRelations [
 	((unaryExpression property: #expression) comment: 'expression')
 	<>- ((tExpression property: #parentExpression) comment:
 			 'Parent expression (if possible)').
+			
+	((assignmentExpression property: #leftPart) comment: 'assignee')
+	<>-
+	((variable property: #parentAssignmentExpression) comment:
+		 'Parent assignment expression').
+		
+	((assignmentExpression property: #rightPart) comment: 'assigned')
+	<>-
+	((variable property: #parentAssignmentExpression) comment:
+		 'Parent assignment expression').	
+			
+	((loopControlExpression property: #init) comment: 'initial assignment')
+	<>-
+	((assignmentExpression property: #parentLoopControlExpresison) comment:
+		 'Parent loop control expresison').	
 
 	((doStatement property: #loopControl) comment: 'loop control')
 	<>-


### PR DESCRIPTION
- Created an entity `FastFortranAssignmentExpression` that has `leftPart` and `rightPart` of `FastFortranVariable`.
- Change type of `init` in `loopControlExpression` to `FastFortranAssignmentExpression`