### PR TITLE
Update .smalltalk.ston to add loaded group

### DIFF
--- a/.smalltalk.ston
+++ b/.smalltalk.ston
@@ -2,7 +2,8 @@ SmalltalkCISpec {
   #loading : [
     SCIMetacelloLoadSpec {
       #baseline : 'FASTFortran',
-      #directory : 'src'
+      #directory : 'src',
+      #load : [ 'all' ]
     }
   ]
 }


### PR DESCRIPTION
On CI, the baseline should load 'all'