### PR TITLE
Removing "obsolete" BinaryExpression

### DIFF
--- a/src/FAST-Fortran-Visitors-Tests/FortranToFASTTests.class.st
+++ b/src/FAST-Fortran-Visitors-Tests/FortranToFASTTests.class.st
@@ -304,6 +304,8 @@ FortranToFASTTests >> testAssignementNegativeIntegerLiteral [
 	self assert: stmt expression class equals: FASTFortranIntegerLiteral.
 	self assert: stmt expression primitiveValue equals: '-1'.
 
+	self assert: (stmt mooseModel allWithType: FASTFortranBinaryExpression) size equals: 0
+
 ]
 
 { #category : 'tests-expression' }
@@ -321,7 +323,9 @@ FortranToFASTTests >> testAssignementNegativeRealLiteral [
 	stmt := result first statementBlock statements first.
 
 	self assert: stmt expression class equals: FASTFortranRealLiteral.
-	self assert: stmt expression primitiveValue equals: '-2.12'
+	self assert: stmt expression primitiveValue equals: '-2.12'.
+
+	self assert: (stmt mooseModel allWithType: FASTFortranBinaryExpression) size equals: 0
 ]
 
 { #category : 'tests-expression' }
@@ -778,6 +782,7 @@ FortranToFASTTests >> testBinaryExpressionUnaryMinus [
 	self assert: expr expression class equals: FASTFortranScalarVariable.
 	self assert: expr expression name equals: 'i'.
 
+	self assert: (expr mooseModel allWithType: FASTFortranBinaryExpression) size equals: 0
 ]
 
 { #category : 'tests-programUnit' }

--- a/src/FAST-Fortran-Visitors/FASTFortranJsonVisitor.class.st
+++ b/src/FAST-Fortran-Visitors/FASTFortranJsonVisitor.class.st
@@ -1448,10 +1448,14 @@ FASTFortranJsonVisitor >> visitType: aTypeNode [
 
 { #category : 'visiting expression' }
 FASTFortranJsonVisitor >> visitUnary: aUnaryNode [
-	"possible negative number, if so invert it and forget about the unaryOperator"
+	"possible negative number, if so invert it and forget about the unaryOperator
+	 the operator is created as a BinaryExpression, need to convert it to UnaryExpression
+	 and drop the binary from the model"
 
 	| data |
 	data := super visitUnary: aUnaryNode.
+
+	model remove: data second.
 
 	(data second operator = '-')
 	ifTrue: [


### PR DESCRIPTION
Removing from the model "obsolete" BinaryExpression entities that are replaced by UnaryExpression + add checks in the tests